### PR TITLE
Add onnxruntime to requirement

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install numpy onnx
+        pip install numpy onnx onnxruntime
         pip install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
         pip install "${{ github.workspace }}[test]"
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ So, this tool convert scale 0 to 1.
 
 ## Installation
 ```bash
-pip3 install numpy onnx
+pip3 install numpy onnx onnxruntime
 pip3 install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com
 pip3 install git+https://github.com/maminus/qdqonnx_scale_0to1.git
 ```

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=[
         'numpy',
         'onnx',
+        'onnxruntime',
         'onnx-graphsurgeon',
     ],
     extras_require={


### PR DESCRIPTION
we need to fold ConstantOfShape node to constant.

[`onnx_graphsurgeon.Graph.fold_constant()`](https://github.com/NVIDIA/TensorRT/blob/release/8.6/tools/onnx-graphsurgeon/onnx_graphsurgeon/ir/graph.py#L862) uses onnxruntime. So onnxruntime is needed in the requirement.

This PR is added onnxruntime to the requirement.